### PR TITLE
Update list.highlightForeground in theme Two

### DIFF
--- a/theme/two.json
+++ b/theme/two.json
@@ -139,7 +139,7 @@
     "list.dropBackground": "#524763",
     "list.focusBackground": "#524763",
     "list.focusForeground": "#eee",
-    "list.highlightForeground": "#524763",
+    "list.highlightForeground": "#82D8D8",
     "list.hoverBackground": "#524763",
     "list.hoverForeground": "#aaa",
     "list.inactiveSelectionBackground": "#524763",


### PR DESCRIPTION
Updated `list.highlightForeground` to improve legibility:

**Old:**
<img width="604" alt="screen shot 2018-07-26 at 9 47 39 pm" src="https://user-images.githubusercontent.com/957488/43302128-9efa61b2-911d-11e8-9a55-f465a7220813.png">

**New:**
<img width="605" alt="screen shot 2018-07-26 at 9 45 28 pm" src="https://user-images.githubusercontent.com/957488/43302134-a3aba8d8-911d-11e8-862d-086ebd88043a.png">